### PR TITLE
feat/ emotion state 수정

### DIFF
--- a/src/pages/SelfDiagnosis/index.jsx
+++ b/src/pages/SelfDiagnosis/index.jsx
@@ -43,6 +43,7 @@ const SelfDiagnosis = () => {
       const response = await axios.post(`/api/emotion/${userAuthState}`, body);
       if (response.status === 201) {
         postSelfDiagnosis(selfEmotion);
+        setEmotionState({ emotion: selfEmotion, time: new Date().toLocaleString() });
         setMeasurementCheckState(true);
         navigate(`/challenge/${selfEmotion}`);
       }


### PR DESCRIPTION
해결사항
- 자가진단에서 post 할 때 recoil emotion state 갱신이 안됨
- 같은 아이디로 감정 측정 후 다시 챌린지 들어가면 리스트가 다르게 뜸
